### PR TITLE
Make series.json location configurable so that the tap is usable in Meltano

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ rsa-key
 tags
 singer-check-tap-data
 state.json
+catalog.json

--- a/README.md
+++ b/README.md
@@ -3,81 +3,90 @@
 This is a [Singer](https://singer.io) tap that produces JSON-formatted data
 following the [Singer
 spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
-If you are reading this description on PyPi and anything looks strange please refer to [the version found on GitHub](https://github.com/frasermarlow/tap-bls)  
+If you are reading this description on PyPi and anything looks strange please refer to [the version found on GitHub](https://github.com/frasermarlow/tap-bls)
 
 This tap pulls raw data from the [Bureau of Labor Statistics (BLS) API](https://www.bls.gov/developers/) as follows:
-1) Provides a sample list of available BLS data series that you can add to your catalog - pick from the list or add your own.
-2) Runs the API to fetch the data series from the BLS and outputs the data to StdOut based on the [Singer.io](http://singer.io) format.
-3) Optionally updates the tap's `STATE.json` file (which is not standard, as the `TARGET.json` typically does this, but this is an option you can set in `CONFIG.json` )
+
+1. Provides a sample list of available BLS data series that you can add to your catalog - pick from the list or add your own.
+2. Runs the API to fetch the data series from the BLS and outputs the data to StdOut based on the [Singer.io](http://singer.io) format.
+3. Optionally updates the tap's `STATE.json` file (which is not standard, as the `TARGET.json` typically does this, but this is an option you can set in `CONFIG.json` )
 
 ---
 
 Copyright &copy; 2020 Stitch
 
 ## PyPi package repo:
+
 https://pypi.org/project/tap-bls/  
-`pip install tap-bls`  
+`pip install tap-bls`
 
-## Extract BLS (Bureau of Labor Statistics) data using Singer.io  
+## Extract BLS (Bureau of Labor Statistics) data using Singer.io
 
-The BLS provides [an API for pulling data from their records](https://www.bls.gov/data/#api), and [Singer.io](https://www.singer.io/) is a common framework for building data flows.  
+The BLS provides [an API for pulling data from their records](https://www.bls.gov/data/#api), and [Singer.io](https://www.singer.io/) is a common framework for building data flows.
 
-## Installation quickguide  
-requirements: Python 3.5.3 & modules os, pytz, sys, json, datetime, backoff, getopt, requests, and Singer  
-1) Create a virtual environment, such as `python3 -m venv ~/.virtualenvs/tap-bls` and activate it with `source ~/.virtualenvs/tap-bls/bin/activate`  
-2) Set the local version of Python to 3.5.3:  `pyenv local 3.5.3`  
-3) Install `wheel` with `pip install --upgrade pip wheel`  
-4) Install the tap in your venv using `pip install tap-bls`  
-5) make a copy of [`sample_config.json`](https://raw.githubusercontent.com/frasermarlow/tap-bls/master/sample_config.json) (as `config.json`) and [`series.json`](https://raw.githubusercontent.com/frasermarlow/tap-bls/master/series.json) (as `series.json`) from the root of the repo into your preferred configuration folder (for example I use `~/tap-bls-config`) 
-6) edit the `config.json` file - the main thing you want to change is the API key ("api-key": in the json file) and put in your BLS API key.  You can even leave this blank if you just want to get started.
-7) run the tap once in 'Discovery mode' to build your `catalog.json` file - your command will look *something* like ```~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --discover > ~/tap-bls-config/catalog.json```
-8) You can now run the tap in standard mode - if you just want to test, run it 'unpiped' with a command such as 
-```~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --catalog ~/tap-bls-config/catalog.json``` 
-but if you have [`tap-csv`](https://github.com/singer-io/target-csv) installed you can make pretty outputs using 
-```~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --catalog ~/tap-bls-config/catalog.json | ~/.virtualenvs/target-csv/bin/target-csv``` 
+## Installation quickguide
 
-> note: when creating the catalog, the schemas will get created following the normal 'schema' process for Singer, adding the definition files in a 'schema' folder within the tap files ( for example in `~\.virtualenvs\tap-bls\lib\python3.6\site-packages\tap_bls\schemas`).  To change the series that you want to pull you will need to delete this folder, edit the `series.json` file, then recreate the catalog by running the discovery mode in step 7 above.
+requirements: Python 3.5.3 & modules os, pytz, sys, json, datetime, backoff, getopt, requests, and Singer
 
-You can use a `--state` file if you like.  This tap provides the option to update the State from the tap, rather than the target.  If you want info on Singer `state` files [check out the docs](https://github.com/singer-io/getting-started/blob/master/docs/CONFIG_AND_STATE.md).
+1. Create a virtual environment, such as `python3 -m venv ~/.virtualenvs/tap-bls` and activate it with `source ~/.virtualenvs/tap-bls/bin/activate`
+2. Set the local version of Python to 3.5.3: `pyenv local 3.5.3`
+3. Install `wheel` with `pip install --upgrade pip wheel`
+4. Install the tap in your venv using `pip install tap-bls`
+5. make a copy of [`sample_config.json`](https://raw.githubusercontent.com/frasermarlow/tap-bls/master/sample_config.json) (as `config.json`) and [`series.json`](https://raw.githubusercontent.com/frasermarlow/tap-bls/master/series.json) (as `series.json`) from the root of the repo into your preferred configuration folder (for example I use `~/tap-bls-config`)
+6. edit the `config.json` file - the main thing you want to change is the API key ("api-key": in the json file) and put in your BLS API key. You can even leave this blank if you just want to get started.
+7. run the tap once in 'Discovery mode' to build your `catalog.json` file - your command will look _something_ like `~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --discover > ~/tap-bls-config/catalog.json`
+8. You can now run the tap in standard mode - if you just want to test, run it 'unpiped' with a command such as
+   `~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --catalog ~/tap-bls-config/catalog.json`
+   but if you have [`tap-csv`](https://github.com/singer-io/target-csv) installed you can make pretty outputs using
+   `~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --catalog ~/tap-bls-config/catalog.json | ~/.virtualenvs/target-csv/bin/target-csv`
+
+> note: when creating the catalog, the schemas will get created following the normal 'schema' process for Singer, adding the definition files in a 'schema' folder within the tap files ( for example in `~\.virtualenvs\tap-bls\lib\python3.6\site-packages\tap_bls\schemas`). To change the series that you want to pull you will need to delete this folder, edit the `series.json` file, then recreate the catalog by running the discovery mode in step 7 above.
+
+You can use a `--state` file if you like. This tap provides the option to update the State from the tap, rather than the target. If you want info on Singer `state` files [check out the docs](https://github.com/singer-io/getting-started/blob/master/docs/CONFIG_AND_STATE.md).
 
 ## So why is this tap cool?
 
-The BLS is the most reliable source of economic data for the USA when it comes to things like unemployment rates, the cost of labor, etc. It also includes Consumer Price Indices, Inflation, Workplace injuries and a bunch  of other useful stuff. [A list of topics can be found here](https://www.bls.gov/bls/topicsaz.htm) and the most popular data series (a.k.a. "The BLS Greatest Hits!") can be found [here](https://data.bls.gov/cgi-bin/surveymost?bls).
+The BLS is the most reliable source of economic data for the USA when it comes to things like unemployment rates, the cost of labor, etc. It also includes Consumer Price Indices, Inflation, Workplace injuries and a bunch of other useful stuff. [A list of topics can be found here](https://www.bls.gov/bls/topicsaz.htm) and the most popular data series (a.k.a. "The BLS Greatest Hits!") can be found [here](https://data.bls.gov/cgi-bin/surveymost?bls).
 
-So say you wanted to know the trend for unemployment during the COVID-19 pandemic of 2020 you could simply [query the API](https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=2019&endyear=2021) and see that it rapidly rose from from 3.5% at the end of 2019 to a high of *14.7%* in April 2020, and back down to 6% by March 2021.
+So say you wanted to know the trend for unemployment during the COVID-19 pandemic of 2020 you could simply [query the API](https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=2019&endyear=2021) and see that it rapidly rose from from 3.5% at the end of 2019 to a high of _14.7%_ in April 2020, and back down to 6% by March 2021.
 
 ## You need to select the BLS series you want to ingest
 
-The volume of data available can quickly get overwhelming.  Just one topic - [Producer Price Indexes - has 318 distinct data series](https://www.bls.gov/ppi/expaggseriesids.htm). Others are so complex, they provide entire excel sheets full of time series references, as is the case for the [American Time Use study](https://www.bls.gov/tus/seriesid.htm). An explanation of [how the BLS structures Series IDs for each topic can be found here](https://www.bls.gov/help/hlpforma.htm).  
+The volume of data available can quickly get overwhelming. Just one topic - [Producer Price Indexes - has 318 distinct data series](https://www.bls.gov/ppi/expaggseriesids.htm). Others are so complex, they provide entire excel sheets full of time series references, as is the case for the [American Time Use study](https://www.bls.gov/tus/seriesid.htm). An explanation of [how the BLS structures Series IDs for each topic can be found here](https://www.bls.gov/help/hlpforma.htm).
 
 A good starting point when looking for available data series is [Databases, Tables & Calculators by Subject](https://www.bls.gov/data/#api) or the [data series by topic](https://www.bls.gov/cps/cpsdbtabs.htm).
 
 With this in mind, the tap provides a framework you can use to ingest BLS data using Singer, but the catalog file would be overwhelming if we attempted to provide every available data series, even if these were maked as `unselected` in the catalog.js. So the tap comes out-of-the-box with a dozen different series taken from some of the most popular ones, but you can configure it for the data series you want to pull in by editing ./series.json.
 
 ## Grab a key
-You can access BLS data without registering a key.  If you do not provide an API key, you will be restricted in the volume of data you can pull. So go to the [BLS registration page](https://data.bls.gov/registrationEngine/) and grab a key. This said, even an authenticated user has limits.
+
+You can access BLS data without registering a key. If you do not provide an API key, you will be restricted in the volume of data you can pull. So go to the [BLS registration page](https://data.bls.gov/registrationEngine/) and grab a key. This said, even an authenticated user has limits.
 
 ## data source API (and limitations thereof)
+
 Our data source is [version 2 of the BLS API](https://www.bls.gov/developers/) which provides a mechanism for grabbing JSON historical timeseries data, along with optional calculations and averages.
 
 The API has some 'fair use' limitations outlined [here](https://www.bls.gov/developers/api_faqs.htm#register1) - namely 50 series per query, 500 daily queries, 50 requests per 10 seconds etc.
 
 The BLS Public API utilizes two HTTP request-response mechanisms to retrieve data: GET and POST. GET requests data from a specified source. POST submits data to a specified resource to be processed. The BLS Public Data API uses GET to request a single piece of information and POST for all other requests.
 
-The BLS have imposed a maximum of 20 years in the query (with the API key - and 10 years without).  Bear this in mind as longer time queries will simply be cut off.
+The BLS have imposed a maximum of 20 years in the query (with the API key - and 10 years without). Bear this in mind as longer time queries will simply be cut off.
 
-Python is the language of choice for Singer.io taps, we are going to stick with that and [sample code is provided here](https://www.bls.gov/developers/api_python.htm#python2).  The BLS provide alternatives in most popular languages.
+Python is the language of choice for Singer.io taps, we are going to stick with that and [sample code is provided here](https://www.bls.gov/developers/api_python.htm#python2). The BLS provide alternatives in most popular languages.
 
 ### endpoints
-HTTP Type:	POST
-URL (JSON):	https://api.bls.gov/publicAPI/v2/timeseries/data/
-Header:	Content-Type= application/json
+
+HTTP Type: POST
+URL (JSON): https://api.bls.gov/publicAPI/v2/timeseries/data/
+Header: Content-Type= application/json
 
 ### query parameters
-The BLS API allows us to query multiple series in a single call, using distinct series IDs.  . Registered users can include up to 50 series IDs, each separated with a comma, in the body of a request. This said, for the ease of execution we are going to call each series one at a time.  Sure, this eats into our 500 daily queries, but after all this data does not chage often (monthly at most).
+
+The BLS API allows us to query multiple series in a single call, using distinct series IDs. . Registered users can include up to 50 series IDs, each separated with a comma, in the body of a request. This said, for the ease of execution we are going to call each series one at a time. Sure, this eats into our 500 daily queries, but after all this data does not chage often (monthly at most).
 
 ## config.json
-This tap requires a config file although none of the parameters are *required*. This said, it will accept the following parameters. We recommend getting and adding your BLS API key to get the most out of the integration:
+
+This tap requires a config file although none of the parameters are _required_. This said, it will accept the following parameters. We recommend getting and adding your BLS API key to get the most out of the integration:
 
 ```
 {
@@ -89,81 +98,82 @@ This tap requires a config file although none of the parameters are *required*. 
   "annualaverage": "false",
   "aspects": "false",
   "disable_collection": "true",
-  "update_state": "false"
+  "update_state": "false",
+  "series_list_file_location": "<absolute or relative path>/series.json"
 }
 ```
 
-- *user-id* is optional.  The BLS specifies it but then it's not passed in the API call ¯\\_(ツ)_/¯
-- *api-key* is your BLS issued API key
-- *start year* is the year you want your data extract to start.  Not the limits: you can pull up to 20 years in one go, and most data seris start at 2000, so you do the math...  If left blank it will default to 2000. [ should be a year as a string - i.e. in quote marks ]
-- *endyear* is when you want the series to end.  If left blank it will default to the current year.  [ should be a year as a string - i.e. in quote marks ]
+- _user-id_ is optional. The BLS specifies it but then it's not passed in the API call ¯\\_(ツ)_/¯
+- _api-key_ is your BLS issued API key
+- _start year_ is the year you want your data extract to start. Not the limits: you can pull up to 20 years in one go, and most data seris start at 2000, so you do the math... If left blank it will default to 2000. [ should be a year as a string - i.e. in quote marks ]
+- _endyear_ is when you want the series to end. If left blank it will default to the current year. [ should be a year as a string - i.e. in quote marks ]
+- _series_list_file_location_ is an optional absolute or relative path to the series.json. If not provided (and if the schemas directory is empty), the tap will look for a file named `series.json` in the same location as the `config.json` file
 
 The next three parameters are explained in more detail [on the BLS website](https://www.bls.gov/developers/api_signature_v2.htm#parameters)
 
-Parameter |  description |  values accepted
-----------|--------------|-----------------
-*calculations*  | provides 1,3,6 and 12 month changes in the data in both net and percentage format.  If selected, these 6 additional datapoints will be included in separate columns. |   will accept "true" or "false"
-*annualaverage* | If selected, an annual data series will include a `M13` datapoint with the annual average value. |   will accept "true" or "false"
-*aspects*       | Returns data series aspect data in the format `[{'name': 'Standard Error', 'value': '-', 'footnotes': [{'code': 'A', 'text': 'Dashes indicate data not available.'}]}]`. Not many BLS series include this. |   will accept "true" or "false"
+| Parameter       | description                                                                                                                                                                                                | values accepted               |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| _calculations_  | provides 1,3,6 and 12 month changes in the data in both net and percentage format. If selected, these 6 additional datapoints will be included in separate columns.                                        | will accept "true" or "false" |
+| _annualaverage_ | If selected, an annual data series will include a `M13` datapoint with the annual average value.                                                                                                           | will accept "true" or "false" |
+| _aspects_       | Returns data series aspect data in the format `[{'name': 'Standard Error', 'value': '-', 'footnotes': [{'code': 'A', 'text': 'Dashes indicate data not available.'}]}]`. Not many BLS series include this. | will accept "true" or "false" |
 
+- _disable_collection_ should theoretically prevent Singer from collecting additional anonymous data on your runs, which are used to help improve Singer. You can set to "true" if you like, although it appears the additional data is collected either way ¯\\_(ツ)_/¯
 
-- *disable_collection* should theoretically prevent Singer from collecting additional anonymous data on your runs, which are used to help improve Singer.  You can set to "true" if you like, although it appears the additional data is collected either way ¯\\_(ツ)_/¯
-
-
-- *update_state* is an uncharacteristic feature for a Singer tap.  The *target* should update `STATE` once it has established that the data has been loaded to the endpoint, but this flag allows you to instruct the `tap` to update `STATE.json` at the end of the run.  So typically you would set this to 'false'.
+- _update_state_ is an uncharacteristic feature for a Singer tap. The _target_ should update `STATE` once it has established that the data has been loaded to the endpoint, but this flag allows you to instruct the `tap` to update `STATE.json` at the end of the run. So typically you would set this to 'false'.
 
 > tap --config CONFIG [--state STATE] [--catalog CATALOG]
 
-STATE and CATALOG are optional arguments both pointing to their own JSON file.  If you do not specify a `state.json` file the tap will generate one in the same folder at the `config.json` file. tap-bls will use `STATE.json` to remember information from the previous invocation such as the point where it left off, namely the year of the most recent data point.
+STATE and CATALOG are optional arguments both pointing to their own JSON file. If you do not specify a `state.json` file the tap will generate one in the same folder at the `config.json` file. tap-bls will use `STATE.json` to remember information from the previous invocation such as the point where it left off, namely the year of the most recent data point.
 
 ## Schema fields
 
-.|Monthly|Quarterly|Semi-Annual|Annual|Format|Note
--------------|-------------|-------------|-------------|-------------|-------------|-------------
-annualaverage|Y*|Y*|Y*|N|float, or Null|If set in config as `"annualaverage": "true"`
-aspects|Y*|Y*|Y*|Y*|Array of json dicts in the format [{'name': 'Standard Error', 'value': '0.1', 'footnotes': [{}]}] - if blank, presented as empty array : `[]`|If set in config as `"aspects": "true"`
-net_change_1|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-net_change_3|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-net_change_6|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-net_change_12|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-pct_change_1|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-pct_change_3|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-pct_change_6|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-pct_change_12|Y*|Y*|Y*|Y*|float|If set in config as `"calculations": "true"`
-record__footnotes|Y*|Y*|Y*|Y*|text|Potentially returns multiple footnotes, although extremely rare.
-record__full_period|Y|Y|Y|Y|DateTime|Complete date for the datapoint.
-record__month|Y|N|N|N|integer|Month (1-12)
-record__period|Y|Y|Y|Y|text|Format examples: "M11","Q2","S02","A01"
-record__quarter|N|Y|N|N|text|
-record__SeriesID|Y|Y|Y|Y|text|The series Id
-record__time_extracted|Y|Y|Y|Y|DateTime|"Complete date plus hours, minutes, seconds and a decimal fraction of a second"
-record__value|Y|Y|Y|Y|float|
-record__year|Y|Y|Y|Y|integer|
-schema|Y|Y|Y|Y|text|The applied schema to this series (same as series id)
-stream|Y|Y|Y|Y|text|
-time_extracted|Y|Y|Y|Y|DateTime|"Complete date plus hours, minutes, seconds and a decimal fraction of a second"
-type|Y|Y|Y|Y|text|RECORD
-frequency|Y|Y|Y|Y|text|Set to 'M','Q','S' or 'A' for monthly, quarterly or annual series.
+| .                        | Monthly | Quarterly | Semi-Annual | Annual | Format                                                                                                                                        | Note                                                                            |
+| ------------------------ | ------- | --------- | ----------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| annualaverage            | Y\*     | Y\*       | Y\*         | N      | float, or Null                                                                                                                                | If set in config as `"annualaverage": "true"`                                   |
+| aspects                  | Y\*     | Y\*       | Y\*         | Y\*    | Array of json dicts in the format [{'name': 'Standard Error', 'value': '0.1', 'footnotes': [{}]}] - if blank, presented as empty array : `[]` | If set in config as `"aspects": "true"`                                         |
+| net_change_1             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| net_change_3             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| net_change_6             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| net_change_12            | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| pct_change_1             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| pct_change_3             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| pct_change_6             | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| pct_change_12            | Y\*     | Y\*       | Y\*         | Y\*    | float                                                                                                                                         | If set in config as `"calculations": "true"`                                    |
+| record\_\_footnotes      | Y\*     | Y\*       | Y\*         | Y\*    | text                                                                                                                                          | Potentially returns multiple footnotes, although extremely rare.                |
+| record\_\_full_period    | Y       | Y         | Y           | Y      | DateTime                                                                                                                                      | Complete date for the datapoint.                                                |
+| record\_\_month          | Y       | N         | N           | N      | integer                                                                                                                                       | Month (1-12)                                                                    |
+| record\_\_period         | Y       | Y         | Y           | Y      | text                                                                                                                                          | Format examples: "M11","Q2","S02","A01"                                         |
+| record\_\_quarter        | N       | Y         | N           | N      | text                                                                                                                                          |
+| record\_\_SeriesID       | Y       | Y         | Y           | Y      | text                                                                                                                                          | The series Id                                                                   |
+| record\_\_time_extracted | Y       | Y         | Y           | Y      | DateTime                                                                                                                                      | "Complete date plus hours, minutes, seconds and a decimal fraction of a second" |
+| record\_\_value          | Y       | Y         | Y           | Y      | float                                                                                                                                         |
+| record\_\_year           | Y       | Y         | Y           | Y      | integer                                                                                                                                       |
+| schema                   | Y       | Y         | Y           | Y      | text                                                                                                                                          | The applied schema to this series (same as series id)                           |
+| stream                   | Y       | Y         | Y           | Y      | text                                                                                                                                          |
+| time_extracted           | Y       | Y         | Y           | Y      | DateTime                                                                                                                                      | "Complete date plus hours, minutes, seconds and a decimal fraction of a second" |
+| type                     | Y       | Y         | Y           | Y      | text                                                                                                                                          | RECORD                                                                          |
+| frequency                | Y       | Y         | Y           | Y      | text                                                                                                                                          | Set to 'M','Q','S' or 'A' for monthly, quarterly or annual series.              |
 
-
-* (*) Note - the value will be included in the schema, but that does not guarantee that the API call we return a value.  Sometimes the data series siply does not include data for this item.
+- (\*) Note - the value will be included in the schema, but that does not guarantee that the API call we return a value. Sometimes the data series siply does not include data for this item.
 
 ## Autogenerating the SCHEMAs
-Typically, the file `CATALOG.json` (generated during discovery) is used to filter which streams should be synced from all the possible streams available in the /schemas/ folder.  
 
-tap-bls behaves a bit differently because of the enormous number of potential data series you migth pull from the BLS.  Therefore it works as follows:
-1) If no `.json` schema files are to be found in the `tap_bls/schemas/` folder, the tap will generate them for you based on the `series.json` file.  The tap will look for the `series.json` file in the same folder as your `config.json` file.  This allows you to rapidly select which BLS data series you want to work with.  A sample 'series.json' file is found in the root of this repo with a bunch of the most popular data seris included, so you can just copy that to your main config folder.
-2) Once you have a set of schema files created (manually or using the automated approach above) you can generate the Singer `catalog.json` file using the tap's --discover mode using a command such as ```~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --discover > catalog.json``` (your set up may use a different folder than 'tap-bls-config' - that is up to you.)
+Typically, the file `CATALOG.json` (generated during discovery) is used to filter which streams should be synced from all the possible streams available in the /schemas/ folder.
+
+tap-bls behaves a bit differently because of the enormous number of potential data series you migth pull from the BLS. Therefore it works as follows:
+
+1. If no `.json` schema files are to be found in the `tap_bls/schemas/` folder, the tap will generate them for you based on the `series.json` file. The tap will look for the `series.json` file in the same folder as your `config.json` file. This allows you to rapidly select which BLS data series you want to work with. A sample 'series.json' file is found in the root of this repo with a bunch of the most popular data seris included, so you can just copy that to your main config folder.
+2. Once you have a set of schema files created (manually or using the automated approach above) you can generate the Singer `catalog.json` file using the tap's --discover mode using a command such as `~/.virtualenvs/tap-bls/bin/tap-bls --config ~/tap-bls-config/config.json --discover > catalog.json` (your set up may use a different folder than 'tap-bls-config' - that is up to you.)
 
 ## A note on series frequency
 
 As far as I can figure out, the BLS provides data series in the following frequencies:
 
-* Monthly - the most common
-* Bi-monthly - very uncommon ( See CUURS12BSA0 ) 
-* Quarterly - fairly common
-* Semi-Annually (6 months) - uncommon, see [CUURS12BSAF](https://data.bls.gov/timeseries/CUURS12BSAF)
-* Annual - fairly common
+- Monthly - the most common
+- Bi-monthly - very uncommon ( See CUURS12BSA0 )
+- Quarterly - fairly common
+- Semi-Annually (6 months) - uncommon, see [CUURS12BSAF](https://data.bls.gov/timeseries/CUURS12BSAF)
+- Annual - fairly common
 
 Bi-monthly and semi-annual appears to be most prevalent in data series related to consumer price index reports.
 
@@ -175,14 +185,13 @@ There is no predefined file structure for building a Singer tap, but here is a l
 
 ![tap-bls file structure](http://frasermarlow.com/img/Slide2.PNG)
 
-
 ## pagination
 
 ## error codes
 
 ## BLS API sourcecode
-https://github.com/OliverSherouse/bls
 
+https://github.com/OliverSherouse/bls
 
 # Open questions and to-dos
 
@@ -192,5 +201,5 @@ WPUFD49104 - Monthly series with annual average
 PRS85006092 - Quarterly series with annual average  
 MPU4910012 - annual series  
 CUURS12BSA0 - bi-monthly series - essentially monthly, but with blank values every other month.  
-https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=1940&endyear=1960  Series starts mid-window  
-Investigate why PRS85006092 returns Q5 data which does not match annual averages.  
+https://api.bls.gov/publicAPI/v2/timeseries/data/LNS14000000?startyear=1940&endyear=1960 Series starts mid-window  
+Investigate why PRS85006092 returns Q5 data which does not match annual averages.

--- a/tap_bls/__init__.py
+++ b/tap_bls/__init__.py
@@ -43,7 +43,7 @@ def main():
 
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
-        catalog = discover(load_schemas())
+        catalog = discover(load_schemas(args.config['series_list_file_location'] if 'series_list_file_location' in args.config else None))
         catalog.dump()
     # Otherwise run in sync mode
     else:

--- a/tap_bls/create_schemas.py
+++ b/tap_bls/create_schemas.py
@@ -5,27 +5,27 @@ fraser marlow - Nov 2020 """
 #
 from __future__ import print_function
 import sys
-import json         # parsing json files
+import json  # parsing json files
 import os
 from os import path
 
 import singer
+
 # from singer.schema import Schema
 # from singer import utils, metadata
 LOGGER = singer.get_logger()
 
+
 def get_series_list(series_list_file_location=None):
-    """ fetches the array of series to create from /series.json in the config folder 
-        
-        Parameters:
-        series_file_path (str): The file path to the series.json file. This can be absolute or relative to the execution directory. If not provided, will look for a file named "series.json" in the same directory as the config.json file
+    """fetches the array of series to create from /series.json in the config folder
+
+    Parameters:
+    series_file_path (str): The file path to the series.json file. This can be absolute or relative to the execution directory. If not provided, will look for a file named "series.json" in the same directory as the config.json file
     """
     series_to_create = {}
 
-    print('111111', series_list_file_location)
     if not series_list_file_location:
-        series_list_file_location = sys.argv[sys.argv.index('--config')+1].rsplit('/', 1)[0]+"/series.json"
-    print("22222", series_list_file_location)
+        series_list_file_location = sys.argv[sys.argv.index("--config") + 1].rsplit("/", 1)[0] + "/series.json"
     if not path.exists(series_list_file_location):
         print("I could not locate file " + series_list_file_location)
     else:
@@ -35,10 +35,10 @@ def get_series_list(series_list_file_location=None):
     return series_to_create
 
 
-
 def get_abs_path(thepath):
     """ fetch the absolute path of a file """
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), thepath)
+
 
 def write_schema_to_file(series, schema_location):
     """ writes the schema to file """
@@ -46,19 +46,35 @@ def write_schema_to_file(series, schema_location):
         with open(schema_location, "w") as jsonFile:
             json.dump(series, jsonFile)
     except Exception as e:
-        LOGGER.info('hit an error creating the schema for %s - %s', series['seriesID'], e)
+        LOGGER.info("hit an error creating the schema for %s - %s", series["seriesID"], e)
     else:
-        LOGGER.info('created schema for series %s', series['seriesID'])
+        LOGGER.info("created schema for series %s", series["seriesID"])
     return
+
 
 def create_schemas(series_list_file_location=None):
     """ creates schemas """
-    print('creating schemas')
+    print("creating schemas")
     schemas_to_create = get_series_list(series_list_file_location)
-    for series in schemas_to_create['series']:
-        if str(series['create_this_schema'].lower()) == "true":
-            schema_json = {"type": ["null", "object"], "additionalProperties":["schema", "record", "type", "stream"], "seriesID" : series['seriesid'], "series_description": series['description'], "key_properties": ["SeriesID", "full_period"], "bookmark_properties": ["time_extracted"], "properties":{"SeriesID":{"type":["null", "string"]}, "period":{"type":["null", "string"]}, "value":{"type":["null", "number"]}, "footnotes":{"type":["null", "string"]}, "full_period":{"type":["null", "string"], "format":"date-time"}, "time_extracted":{"type":["null", "string"], "format":"date-time"}}}
-            schema_file = series['seriesid'] + ".json"
-            schema_location = get_abs_path('schemas') + "/" + schema_file
+    for series in schemas_to_create["series"]:
+        if str(series["create_this_schema"].lower()) == "true":
+            schema_json = {
+                "type": ["null", "object"],
+                "additionalProperties": ["schema", "record", "type", "stream"],
+                "seriesID": series["seriesid"],
+                "series_description": series["description"],
+                "key_properties": ["SeriesID", "full_period"],
+                "bookmark_properties": ["time_extracted"],
+                "properties": {
+                    "SeriesID": {"type": ["null", "string"]},
+                    "period": {"type": ["null", "string"]},
+                    "value": {"type": ["null", "number"]},
+                    "footnotes": {"type": ["null", "string"]},
+                    "full_period": {"type": ["null", "string"], "format": "date-time"},
+                    "time_extracted": {"type": ["null", "string"], "format": "date-time"},
+                },
+            }
+            schema_file = series["seriesid"] + ".json"
+            schema_location = get_abs_path("schemas") + "/" + schema_file
 
             write_schema_to_file(schema_json, schema_location)

--- a/tap_bls/create_schemas.py
+++ b/tap_bls/create_schemas.py
@@ -14,16 +14,22 @@ import singer
 # from singer import utils, metadata
 LOGGER = singer.get_logger()
 
-def get_series_list():
-    """ fetches the array of series to create from /series.json in the config folder """
+def get_series_list(series_list_file_location=None):
+    """ fetches the array of series to create from /series.json in the config folder 
+        
+        Parameters:
+        series_file_path (str): The file path to the series.json file. This can be absolute or relative to the execution directory. If not provided, will look for a file named "series.json" in the same directory as the config.json file
+    """
     series_to_create = {}
 
-    series_list = sys.argv[sys.argv.index('--config')+1].rsplit('/', 1)[0]+"/series.json"
-
-    if not path.exists(series_list):
-        print("I could not locate file " + series_list)
+    print('111111', series_list_file_location)
+    if not series_list_file_location:
+        series_list_file_location = sys.argv[sys.argv.index('--config')+1].rsplit('/', 1)[0]+"/series.json"
+    print("22222", series_list_file_location)
+    if not path.exists(series_list_file_location):
+        print("I could not locate file " + series_list_file_location)
     else:
-        with open(series_list, "r") as jsonFile:
+        with open(series_list_file_location, "r") as jsonFile:
             series_to_create = json.load(jsonFile)
 
     return series_to_create
@@ -45,9 +51,10 @@ def write_schema_to_file(series, schema_location):
         LOGGER.info('created schema for series %s', series['seriesID'])
     return
 
-def create_schemas():
+def create_schemas(series_list_file_location=None):
     """ creates schemas """
-    schemas_to_create = get_series_list()
+    print('creating schemas')
+    schemas_to_create = get_series_list(series_list_file_location)
     for series in schemas_to_create['series']:
         if str(series['create_this_schema'].lower()) == "true":
             schema_json = {"type": ["null", "object"], "additionalProperties":["schema", "record", "type", "stream"], "seriesID" : series['seriesid'], "series_description": series['description'], "key_properties": ["SeriesID", "full_period"], "bookmark_properties": ["time_extracted"], "properties":{"SeriesID":{"type":["null", "string"]}, "period":{"type":["null", "string"]}, "value":{"type":["null", "number"]}, "footnotes":{"type":["null", "string"]}, "full_period":{"type":["null", "string"], "format":"date-time"}, "time_extracted":{"type":["null", "string"], "format":"date-time"}}}

--- a/tap_bls/discover.py
+++ b/tap_bls/discover.py
@@ -5,7 +5,6 @@ import os
 import json
 
 
-
 from singer import metadata
 from singer.schema import Schema
 from singer.catalog import Catalog, CatalogEntry
@@ -17,36 +16,37 @@ def get_abs_path(thepath):
     """ get the file absolute path """
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), thepath)
 
+
 # go into the local 'schemas' folder, and pare through all the .json files you find there.
-def load_schemas():
+def load_schemas(series_list_file_location=None):
     """ load the schemas """
     ### Load schemas from schemas folder ###
     schemas = {}
-    schemas_path = get_abs_path('schemas')
+    schemas_path = get_abs_path("schemas")
 
     # If the '/schemas/ folder is missing, create it.
     if not os.path.isdir(schemas_path):
         os.mkdir(schemas_path)
 
     # If no schemas are found in the /schemas/ folder, then generate them using create_schemas.py
-    if [name for name in os.listdir(schemas_path) if os.path.isfile(os.path.join(schemas_path, name))]:
-        create_schemas()
+    if len([name for name in os.listdir(schemas_path) if os.path.isfile(os.path.join(schemas_path, name))]) == 0:
+        create_schemas(series_list_file_location)
 
     # now grab the .json files in /schemas/ and output the catalog.json file.
-
     for filename in os.listdir(schemas_path):
-        path = schemas_path + '/' + filename
-        file_raw = filename.replace('.json', '')
+        path = schemas_path + "/" + filename
+        file_raw = filename.replace(".json", "")
         with open(path) as f:
             schemas[file_raw] = Schema.from_dict(json.load(f))
-    return schemas   # returns a 'dict' that contains <class 'singer.schema.Schema'> objects
+    return schemas  # returns a 'dict' that contains <class 'singer.schema.Schema'> objects
+
 
 def discover(raw_schemas):
     """ run the discover mode """
     streams = []
     for stream_id, schema in raw_schemas.items():
         # TODO: populate any metadata and stream's key properties here..
-        stream_metadata = [{"metadata":{"inclusion":"available", "selected":"true"}, "breadcrumb":[]}]
+        stream_metadata = [{"metadata": {"inclusion": "available", "selected": "true"}, "breadcrumb": []}]
         key_properties = ["year"]
         rep_key = ["year"]
         rep_method = None
@@ -63,10 +63,11 @@ def discover(raw_schemas):
                 row_count=None,
                 stream_alias=None,
                 replication_method=rep_method,
-                schema=schema
+                schema=schema,
             )
         )
-    return Catalog(streams) # object with class 'singer.catalog.Catalog'
+    return Catalog(streams)  # object with class 'singer.catalog.Catalog'
+
 
 #  everything below is from the Adroll tap
 
@@ -80,6 +81,7 @@ def _load_schemas():
         with open(path) as f:
             schemas[file_raw] = json.load(f)
     return schemas
+
 
 def do_discover():
     """ run the discovery process """
@@ -100,7 +102,7 @@ def do_discover():
                 valid_replication_keys=stream.replication_keys,
                 replication_method=stream.replication_method,
             ),
-            "key_properties": stream.key_properties
+            "key_properties": stream.key_properties,
         }
         catalog_entries.append(catalog_entry)
 


### PR DESCRIPTION
## Why?
This change makes the tap usable in Meltano by making the series.json location configurable

## Related issues
Closes #1 

## Change Notes
Added a new config property, `series_list_file_location` that makes the series.json file location configurable. If the prop is not provided, then the tap defaults to the old behavior of looking for a file named `series.json` in the same directory as the `config.json` file

Although the linter made many changes to the README.md file, the only meaningful changes are on lines 102 and 110, which document the `series_list_file_location` config property.

Althought the linter made changes to some of the modified python files, the meaningful change is at https://github.com/frasermarlow/tap-bls/compare/master...Datateer:master#diff-1c68cee849c6443b344b91c2ebe78b53c9171f522e19425e75487d50557134b8R19-R32

I corrected a related bug on line 32 of discover.py https://github.com/frasermarlow/tap-bls/compare/master...Datateer:master#diff-524e3150f7fdba9c533d110e312eada242e560e6c26d14349747bd44727dc74bR32