### PR TITLE
Make tap work with meltano/target-postgres out of the box

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         "jsonschema==2.6.0","pylint==1.8.3",
         "pytz==2018.4","pytzdata==2020.1",
         "requests==2.20.0","simplejson==3.11.1",
-        "singer-encodings==0.0.3","singer-python==5.9.0","singer-tools==0.4.1"
+        "singer-encodings==0.0.3","singer-python==5.9.0","singer-tools==0.4.1",
+        "python-dateutil==2.8.2"
     ],
     entry_points="""
     [console_scripts]

--- a/tap_bls/__init__.py
+++ b/tap_bls/__init__.py
@@ -41,16 +41,18 @@ def main():
     if not args.state:    # if no state was provided
         generate_state()        # ... generate one
 
+    series_list_file_location = args.config.get('series_list_file_location', None)
+
     # If discover flag was passed, run discovery mode and dump output to stdout
     if args.discover:
-        catalog = discover(load_schemas(args.config['series_list_file_location'] if 'series_list_file_location' in args.config else None))
+        catalog = discover(load_schemas(series_list_file_location))
         catalog.dump()
     # Otherwise run in sync mode
     else:
         if args.catalog:
             catalog = args.catalog
         else:
-            catalog = discover(load_schemas())
+            catalog = discover(load_schemas(series_list_file_location))
             LOGGER.info("You did not specify a catalog.json file, so I will create one.")
         if not catalog.streams:
             LOGGER.info("The catalog.json file exists, but is empty.")

--- a/tap_bls/create_schemas.py
+++ b/tap_bls/create_schemas.py
@@ -66,6 +66,7 @@ def create_schemas(series_list_file_location=None):
                 "bookmark_properties": ["time_extracted"],
                 "properties": {
                     "SeriesID": {"type": ["null", "string"]},
+                    "year": {"type": ["null", "number"]},
                     "period": {"type": ["null", "string"]},
                     "value": {"type": ["null", "number"]},
                     "footnotes": {"type": ["null", "string"]},

--- a/tap_bls/sync.py
+++ b/tap_bls/sync.py
@@ -1,6 +1,7 @@
 """ Core Synch module for tap-BLS """
 #!/usr/bin/env python3
 import datetime     # time and dates functions
+import dateutil
 import singer
 # from singer import Transformer, metadata
 import pytz         # timestamp localization / timezones
@@ -165,23 +166,16 @@ def do_sync(config, state, catalog):
                         footnotes = footnotes + footnote['text'] + ','
 
                 next_row = {
-                    "type":"RECORD",
-                    "stream": seriesId,
-                    "time_extracted": time_extracted,
-                    "schema":seriesId,
-                    "frequency":series_frequency,
-                    "record":{
-                        "SeriesID": seriesId,
-                        "year": year,
-                        "period": period,
-                        "value": value,
-                        "footnotes":footnotes[0:-1],
-                        "month": str(month),
-                        "quarter":str(quarter),
-                        "time_extracted":time_extracted,
-                        "full_period":full_period
-                        }
-                    }
+                    "SeriesID": seriesId,
+                    "year": year,
+                    "period": period,
+                    "value": value,
+                    "footnotes":footnotes[0:-1],
+                    "month": str(month),
+                    "quarter":str(quarter),
+                    "time_extracted":time_extracted,
+                    "full_period":full_period
+                }
 
 
                 if ("calculations" in config.keys()) and (config['calculations'].lower() == "true"):
@@ -213,17 +207,17 @@ def do_sync(config, state, catalog):
                     else:
                         next_row['annualaverage'] = None
 
-                # write one or more rows to the stream:
-                singer.write_records(stream.tap_stream_id, [next_row])
+                # write one row to the stream:
+                singer.write_record(stream.tap_stream_id, next_row, time_extracted=dateutil.parser.isoparse(time_extracted))
                 # capture stream state
                 if bookmark_column:
 
                     if is_sorted:
                         # update bookmark to latest value - this is redundant for tap-bls
-                        singer.write_state({stream.tap_stream_id: next_row["record"][bookmark_column[0]]})
+                        singer.write_state({stream.tap_stream_id: next_row[bookmark_column[0]]})
                     else:
                         # if data unsorted, save max value until end of writes.  tap-bls goes by the year and will use this approach
-                        max_bookmark = max(max_bookmark, int(next_row["record"][bookmark_column[0]]))
+                        max_bookmark = max(max_bookmark, int(next_row[bookmark_column[0]]))
 
         if bookmark_column and not is_sorted:
             singer.write_state({stream.tap_stream_id: max_bookmark})

--- a/tap_bls/sync.py
+++ b/tap_bls/sync.py
@@ -158,7 +158,7 @@ def do_sync(config, state, catalog):
                 # if series_frequency == "M":
                 #    next_row['month'] = item['something']
 
-                full_period = str(year) + "-" + str("{0:0=2d}".format(month)) + "-01T00:00:00-04:00"
+                full_period = str(year) + "-" + str("{0:0=2d}".format(max(month, 1))) + "-01T00:00:00-04:00"
                 footnotes = ""
                 for footnote in item['footnotes']:
                     if footnote:


### PR DESCRIPTION
This PR fixes a few issues I ran into attempting to use this tap out of the box with `target-postgres` with meltano:

1. `year` was not specified in the schema properties in `create_schema` even though it is specified in `key_properties` when creating the `CatalogEntry` in `discover`. This caused `target-postgres` to throw an error due to trying to create a primary key on a column that doesn't exist when creating the tables.
2. When running in sync mode with no catalog specified, `load_schemas` is called without passing the `series_list_file_location` specified in the config.
3. `singer.write_records` is being incorrectly called with a full `RECORD` object. The `write_record` function creates a `RECORD` object itself, and sets the `record` field of that object to the passed input. This results in the tap outputting a message which looks like `{"type": "RECORD", "record": {"type": "RECORD", "record": { ... } } }` rather than `{"type": "RECORD", "record": { ... } }`
4. When a month is not available for a row, the month in `full_period` will be set to `00`. This is an invalid date and results in an error when inserting the row into the database.