### PR TITLE
remove hardcoded casting

### DIFF
--- a/tap_bls/sync.py
+++ b/tap_bls/sync.py
@@ -149,7 +149,7 @@ def do_sync(config, state, catalog):
                 else:
                     month = ""
                     quarter = ""
-                value = float(item['value'])
+                value = item['value']
 
                 # if series_frequency == "A":
                 #    next_row['year'] = item['something']


### PR DESCRIPTION
allow the 'value' property to provide non-numeric values, which happens sometimes from BLS data. A dash (-) is sometimes the value, indicating a zero or null

Resolves #5 