### PR TITLE
Introducing support for -c flag as an alternative to --config.

### DIFF
--- a/tap_bls/create_schemas.py
+++ b/tap_bls/create_schemas.py
@@ -20,10 +20,14 @@ def get_series_list(series_list_file_location=None):
     series_to_create = {}
 
     if not series_list_file_location:
-        config_index = sys.argv.index('--config') + 1
+        if '--config' in sys.argv:
+            config_index = sys.argv.index('--config') + 1
+        elif '-c' in sys.argv:
+            config_index = sys.argv.index('-c') + 1
         config_path = sys.argv[config_index]
         directory = os.path.dirname(config_path) if '/' in config_path else '.'
         series_list_file_location = os.path.join(directory, "series.json")
+
     if not path.exists(series_list_file_location):
         print("I could not locate file " + series_list_file_location)
     else:

--- a/tap_bls/update_state.py
+++ b/tap_bls/update_state.py
@@ -11,10 +11,20 @@ from os import path
 
 def generate_state():
     """ If the STATE.json file is missing, create one """
-    config_index = sys.argv.index('--config') + 1
+    if '--config' in sys.argv:
+        config_index = sys.argv.index('--config') + 1
+    elif '-c' in sys.argv:
+        config_index = sys.argv.index('-c') + 1
+    else:
+        raise ValueError("Missing required argument: --config or -c")
+
+    if config_index >= len(sys.argv):
+        raise ValueError("Config path not provided")
+
     config_path = sys.argv[config_index]
     directory = path.dirname(config_path) if '/' in config_path else '.'
     state_file = path.join(directory, "state.json")
+
     if not path.exists(state_file):
         data = {"bookmarks": {}}
         with open(state_file, "w") as jsonFile:
@@ -22,6 +32,7 @@ def generate_state():
         result = True
     else:
         result = False
+
     return result
 
 def update_state(state_updates):
@@ -31,7 +42,11 @@ def update_state(state_updates):
         state_file = sys.argv[sys.argv.index('--state')+1]
     except Exception as e1:
         try:
-            state_file = sys.argv[sys.argv.index('--config')+1].rsplit('/', 1)[0]+"/state.json"
+            if '--config' in sys.argv:
+                config_index = sys.argv.index('--config') + 1
+            elif '-c' in sys.argv:
+                config_index = sys.argv.index('-c') + 1
+            state_file = sys.argv[config_index].rsplit('/', 1)[0]+"/state.json"
         except Exception as e2:
             info = "No 'state.json' file was specified and could not be generated in the config folder. " + e1 + " | " + e2
 


### PR DESCRIPTION
Addresses a set-up situation where only the `--config` flag was being checked and not the `-c` alternative.